### PR TITLE
Update for cats 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ import scala.concurrent.ExecutionContext.Implicits.global
 val parser = StreamParser.fromInputStream(/* a java.io.InputStream */)
 
 // Now you can run one of the actions you've constructed earlier
-run(parser)(allBookTags) // runs it into a Future[StreamError Xor Vector[Tag]]
+run(parser)(allBookTags) // runs it into a Future[Either[StreamError, Vector[Tag]]]
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ scalaVersion := "2.11.8"
 organization := "io.github.amrhassan"
 
 libraryDependencies ++= Seq(
-  "org.typelevel" %% "cats-core" % "0.7.2",
-  "org.typelevel" %% "cats-free" % "0.7.2",
+  "org.typelevel" %% "cats-core" % "0.8.0",
+  "org.typelevel" %% "cats-free" % "0.8.0",
   "com.fasterxml.woodstox" % "woodstox-core" % "5.0.2",
   "org.specs2" %% "specs2-core" % "3.8.5" % "test",
   "org.specs2" %% "specs2-cats" % "3.8.5" % "test"

--- a/src/main/scala/exemelle/interface.scala
+++ b/src/main/scala/exemelle/interface.scala
@@ -1,7 +1,7 @@
 package exemelle
 
 import scala.concurrent.{ExecutionContext, Future}
-import cats.data.{Xor, XorT}
+import cats.data.EitherT
 import cats.free.Free
 import cats.implicits._
 
@@ -120,7 +120,7 @@ object StreamAction {
         findAllTagsNamed(name) map (tag.toVector ++ _)
     }
 
-  def run[A](parser: StreamParser)(action: StreamAction[A])(implicit ec: ExecutionContext): Future[StreamError Xor A] =
-    action.foldMap[XorT[Future, StreamError, ?]](parser).value
+  def run[A](parser: StreamParser)(action: StreamAction[A])(implicit ec: ExecutionContext): Future[Either[StreamError, A]] =
+    action.foldMap[EitherT[Future, StreamError, ?]](parser).value
 }
 

--- a/src/main/scala/exemelle/package.scala
+++ b/src/main/scala/exemelle/package.scala
@@ -1,9 +1,10 @@
-import scala.concurrent.Future
-import cats.data.XorT
+import cats.data.EitherT
 import cats.free.Free
 import cats.~>
 
+import scala.concurrent.Future
+
 package object exemelle {
   type StreamAction[A] = Free[StreamOp, A]
-  type StreamParser = StreamOp ~> XorT[Future, StreamError, ?]
+  type StreamParser = StreamOp ~> EitherT[Future, StreamError, ?]
 }

--- a/src/test/scala/exemelle/StreamActionSpec.scala
+++ b/src/test/scala/exemelle/StreamActionSpec.scala
@@ -3,7 +3,6 @@ package exemelle
 import org.specs2._
 import Testing._
 import StreamAction._
-import cats.data.Xor
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
@@ -18,7 +17,7 @@ class StreamActionSpec extends Specification { def is = s2"""
 
     val first =
       testRun(parser, action) must beLike {
-        case Xor.Right(Some(tag)) ⇒ tag.originalText must be equalTo
+        case Right(Some(tag)) ⇒ tag.originalText must be equalTo
           """<food>
             |        <food><name>This is fake</name></food>
             |        <name>Belgian Waffles</name>
@@ -32,7 +31,7 @@ class StreamActionSpec extends Specification { def is = s2"""
 
     val second =
       testRun(parser, action) must beLike {
-        case Xor.Right(Some(tag)) ⇒ tag.originalText must be equalTo
+        case Right(Some(tag)) ⇒ tag.originalText must be equalTo
           """<food>
             |        <food><name>This is fake</name></food>
             |        <name>Strawberry Belgian Waffles</name>
@@ -44,7 +43,7 @@ class StreamActionSpec extends Specification { def is = s2"""
             |    </food>""".stripMargin
       }
 
-    val third = testRun(parser, action) must beLike { case Xor.Right(None) ⇒ ok }
+    val third = testRun(parser, action) must beLike { case Right(None) ⇒ ok }
 
     first and second and third
   }

--- a/src/test/scala/exemelle/Testing.scala
+++ b/src/test/scala/exemelle/Testing.scala
@@ -2,7 +2,6 @@ package exemelle
 
 import java.io.InputStream
 import scala.concurrent.Await
-import cats.data.Xor
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -13,6 +12,6 @@ object Testing {
 
   def createBreakfastMenuParser = UnsafeStreamParser(breakfastMenu)
 
-  def testRun[A](parser: StreamParser, action: StreamAction[A]): StreamError Xor A =
+  def testRun[A](parser: StreamParser, action: StreamAction[A]): Either[StreamError, A] =
     Await.result(StreamAction.run(parser)(action), 1 minute)
 }

--- a/src/test/scala/exemelle/UnsafeStreamParserSpec.scala
+++ b/src/test/scala/exemelle/UnsafeStreamParserSpec.scala
@@ -1,30 +1,29 @@
 package exemelle
 
-import cats.data.Xor
 import org.specs2._
-import org.specs2.matcher.XorMatchers
+import org.specs2.matcher.EitherMatchers
 
-class UnsafeStreamParserSpec extends Specification with XorMatchers { def is = s2"""
+class UnsafeStreamParserSpec extends Specification with EitherMatchers { def is = s2"""
   First element is a StartDocument    $firstElement
   Next-ing order is correct           $nexting
   Peek-ing is correct                 $peeking
   """
 
   def firstElement =
-    Testing.createBreakfastMenuParser.getNext() must beLike { case Xor.Right(Some(elem: StartDocument)) ⇒ ok }
+    Testing.createBreakfastMenuParser.getNext() must beLike { case Right(Some(elem: StartDocument)) ⇒ ok }
 
   def nexting = {
     val parser = Testing.createBreakfastMenuParser
     val _ = parser.getNext()
 
     val first =
-      parser.getNext() must beLike { case Xor.Right(Some(elem: StartTag)) ⇒ elem.text must beEqualTo("<breakfast_menu>") }
+      parser.getNext() must beLike { case Right(Some(elem: StartTag)) ⇒ elem.text must beEqualTo("<breakfast_menu>") }
 
     val second =
-      parser.getNext() must beLike { case Xor.Right(Some(elem: Text)) ⇒ ok }
+      parser.getNext() must beLike { case Right(Some(elem: Text)) ⇒ ok }
 
     val third =
-      parser.getNext() must beLike { case Xor.Right(Some(elem: StartTag)) ⇒ elem.text must beEqualTo("<food>") }
+      parser.getNext() must beLike { case Right(Some(elem: StartTag)) ⇒ elem.text must beEqualTo("<food>") }
 
     first and second and third
   }
@@ -33,22 +32,22 @@ class UnsafeStreamParserSpec extends Specification with XorMatchers { def is = s
     val parser = Testing.createBreakfastMenuParser
 
     val peekFirst =
-      parser.peek() must beLike { case Xor.Right(Some(elem: StartDocument)) ⇒ ok }
+      parser.peek() must beLike { case Right(Some(elem: StartDocument)) ⇒ ok }
 
     val peekSecond =
-      parser.peek() must beLike { case Xor.Right(Some(elem: StartDocument)) ⇒ ok }
+      parser.peek() must beLike { case Right(Some(elem: StartDocument)) ⇒ ok }
 
     val first =
-      parser.getNext() must beLike { case Xor.Right(Some(elem: StartDocument)) ⇒ ok }
+      parser.getNext() must beLike { case Right(Some(elem: StartDocument)) ⇒ ok }
 
     val second =
-      parser.getNext() must beLike { case Xor.Right(Some(elem: StartTag)) ⇒ elem.text must beEqualTo("<breakfast_menu>") }
+      parser.getNext() must beLike { case Right(Some(elem: StartTag)) ⇒ elem.text must beEqualTo("<breakfast_menu>") }
 
     val peekThird =
-      parser.peek() must beLike { case Xor.Right(Some(elem: Text)) ⇒ ok }
+      parser.peek() must beLike { case Right(Some(elem: Text)) ⇒ ok }
 
     val third =
-      parser.peek() must beLike { case Xor.Right(Some(elem: Text)) ⇒ ok }
+      parser.peek() must beLike { case Right(Some(elem: Text)) ⇒ ok }
 
     peekFirst and peekSecond and first and second and peekThird and third
   }


### PR DESCRIPTION
Minimal changes needed to upgrade version of cats. 
`Xor` -> `Either`, `XorT` -> `EitherT`. I pick `Either[A, B]` syntax over `A Either B` since former is more readable IMO (we have this convention inside my team). 

